### PR TITLE
Converting Methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},
     namespace: config.namespace,
     camelCase: config.camelCase || false,
-    stringLiteralTypesInsteadOfEnums: config.stringLiteralTypesInsteadOfEnums || false
+    stringLiteralTypesInsteadOfEnums: config.stringLiteralTypesInsteadOfEnums || false,
+    returnPromise: config.returnPromise || false,
+    includeMethods : config.includeMethods || false
 });
 
 const dotnetProject = path.join(__dirname, 'lib/csharp-models-to-json');

--- a/lib/csharp-models-to-json/InterfaceCollector.cs
+++ b/lib/csharp-models-to-json/InterfaceCollector.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CSharpModelsToJson
+{
+  public class Interface
+  {
+    public string ClassName { get; set; }
+    public IEnumerable<Field> Fields { get; set; }
+    public IEnumerable<Property> Properties { get; set; }
+    public IEnumerable<Method> Methods { get; set; }
+    public string BaseClasses { get; set; }
+  }
+
+  public class Method
+  {
+    public string Name { get; set; }
+    public IEnumerable<Parameter> Params { get; set; }
+    public string ReturnType { get; set; }
+
+  }
+
+  public class Parameter
+  {
+    public string Identifier { get; set; }
+    public string Type { get; set; }
+    public DefaultValue Default { get; set; }
+  }
+
+  public class DefaultValue
+  {
+    public string Value { get; set; }
+    public bool IsNull { get; set; }
+  }
+
+  public class InterfaceCollector : CSharpSyntaxWalker
+  {
+    public readonly List<Interface> Items = new List<Interface>();
+    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+    {
+
+      var item = new Interface()
+      {
+        ClassName = node.Identifier.ToString(),
+        Fields = node.Members.OfType<FieldDeclarationSyntax>()
+              .Where(field => !field.Modifiers.Any(modifier => modifier.ToString() == "const" || modifier.ToString() == "static" || modifier.ToString() == "private"))
+              .Select(field => new Field
+              {
+                Identifier = field.Declaration.Variables.First().GetText().ToString(),
+                Type = field.Declaration.Type.ToString(),
+              }),
+
+        Methods = node.Members.OfType<MethodDeclarationSyntax>()
+          .Where(method => !method.Modifiers.Any(modifier => modifier.ToString() == "private" || modifier.ToString() == "static"))
+          .Select(method => new Method {
+            Name = method.Identifier.Text,
+            ReturnType = method.ReturnType.ToString(),
+            Params = method.ParameterList.Parameters.Select(parameter => new Parameter
+            {
+              Identifier = parameter.Identifier.Text,
+              Type = parameter.Type.ToString(),
+              Default = parameter.Default != null ? new DefaultValue
+              {
+                Value = parameter.Default.Value.GetLastToken().Value != null ? parameter.Default.Value.GetLastToken().Value.ToString() : parameter.Default.Value.GetLastToken().ValueText,
+                IsNull = parameter.Default.Value.GetLastToken().Kind().ToString() == "NullKeyword"
+              } : null
+            })
+          }),
+
+        Properties = node.Members.OfType<PropertyDeclarationSyntax>()
+              .Where(property => !property.Modifiers.Any(modifier => modifier.ToString() == "const" || modifier.ToString() == "static" || modifier.ToString() == "private"))
+              .Select(property => new Property {
+                Identifier = property.Identifier.ToString(),
+                Type = property.Type.ToString(),
+              }),
+        BaseClasses = node.BaseList?.Types.ToString(),
+      };
+
+      this.Items.Add(item);
+    }
+  }
+
+}

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,6 +12,7 @@ namespace CSharpModelsToJson
         public string FileName { get; set; }
         public IEnumerable<Class> Classes { get; set; }
         public IEnumerable<Enum> Enums { get; set; }
+        public IEnumerable<Interface> Interfaces { get; set; }
     }
 
     class Program
@@ -71,14 +72,17 @@ namespace CSharpModelsToJson
  
             var classCollector = new ClassCollector();
             var enumCollector = new EnumCollector();
+            var interfaceCollector = new InterfaceCollector();
 
             classCollector.Visit(root); 
             enumCollector.Visit(root);
+            interfaceCollector.Visit(root);
 
             return new File() {
                 FileName = System.IO.Path.GetFullPath(path),
                 Classes = classCollector.Items,
-                Enums = enumCollector.Items
+                Enums = enumCollector.Items,
+                Interfaces = interfaceCollector.Items
             };
         }
     }

--- a/lib/csharp-models-to-json_test/Methods_test.cs
+++ b/lib/csharp-models-to-json_test/Methods_test.cs
@@ -1,0 +1,177 @@
+﻿using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace CSharpModelsToJson.Tests
+{
+    [TestFixture]
+    public class MethodsTest
+    {
+        [Test]
+        public void BasicMethodInInterface()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public interface Cheese
+                {
+                    public void Consume();
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var interfaceCollector = new InterfaceCollector();
+
+            interfaceCollector.Visit(root);
+
+            Assert.AreEqual(interfaceCollector.Items.Count, 1);
+            Assert.AreEqual(interfaceCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().ReturnType, "void");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Params.Any(), false);
+
+        }
+
+        [Test]
+        public void BasicMethodInClass()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public class Cheese
+                {
+                    public void Consume() {}
+                    private void Dispose() {}
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var classCollector = new ClassCollector();
+
+            classCollector.Visit(root);
+
+            Assert.AreEqual(classCollector.Items.Count, 1);
+            Assert.AreEqual(classCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(classCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(classCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(classCollector.Items.First().Methods.First().ReturnType, "void");
+            Assert.AreEqual(classCollector.Items.First().Methods.First().Params.Any(), false);
+
+        }
+
+        [Test]
+        public void BasicMethodInInterfaceIntParam()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public interface Cheese
+                {
+                    public void Consume(int mouthfuls);
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var interfaceCollector = new InterfaceCollector();
+
+            interfaceCollector.Visit(root);
+
+            Assert.AreEqual(interfaceCollector.Items.Count, 1);
+            Assert.AreEqual(interfaceCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().ReturnType, "void");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Params.Any(param => param.Identifier == "mouthfuls" && param.Type == "int"), true);
+
+        }
+
+        [Test]
+        public void BasicMethodInInterfaceOptionalIntParam()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public interface Cheese
+                {
+                    public void Consume(int mouthfuls = 0);
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var interfaceCollector = new InterfaceCollector();
+
+            interfaceCollector.Visit(root);
+
+            Assert.AreEqual(interfaceCollector.Items.Count, 1);
+            Assert.AreEqual(interfaceCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().ReturnType, "void");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Params.Any(param => param.Identifier == "mouthfuls" && param.Type == "int" && param.Default != null), true);
+
+        }
+
+        [Test]
+        public void BasicMethodInInterfaceReturnGuid()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public interface Cheese
+                {
+                    public Guid Consume();
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var interfaceCollector = new InterfaceCollector();
+
+            interfaceCollector.Visit(root);
+
+            Assert.AreEqual(interfaceCollector.Items.Count, 1);
+            Assert.AreEqual(interfaceCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().ReturnType, "Guid");
+
+        }
+
+        [Test]
+        public void BasicMethodInInterfaces()
+        {
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public interface Cheese
+                {
+                    public Guid Consume();
+                }
+
+                public interface Tea
+                {
+                    public void Drink(bool isNoon);
+                }
+"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+            var interfaceCollector = new InterfaceCollector();
+
+            interfaceCollector.Visit(root);
+
+            Assert.AreEqual(interfaceCollector.Items.Count, 2);
+            Assert.AreEqual(interfaceCollector.Items.First().ClassName, "Cheese");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Name, "Consume");
+            Assert.AreEqual(interfaceCollector.Items.First().Methods.First().Params.Count(), 0);
+
+            Assert.AreEqual(interfaceCollector.Items.Last().ClassName, "Tea");
+            Assert.AreEqual(interfaceCollector.Items.Last().Methods.Count(), 1);
+            Assert.AreEqual(interfaceCollector.Items.Last().Methods.First().Name, "Drink");
+            Assert.AreEqual(interfaceCollector.Items.Last().Methods.First().Params.Any(param => param.Identifier == "isNoon" && param.Type == "bool"), true);
+
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
Hi.

In a project we needed to convert C# interfaces into TypeScript, and one crucial part of this was that the methods of the interfaces were incldued as well..

I really liked the look of this project of yours and I took the liberty to add some basic functionality to include the methods as well.

- The methods are included in both classes and interfaces
- I added the new boolean option `methods` (default: false) that can be set to *true* to include methods.
- I added the new boolean option `returnPromise` (default false) to return the type as a promise from the generated method code
- Parameters with default values in the C# interface will become optional? in the TypeScript interface

This C# code:

```
namespace SomeInterfaces
{
  public interface ISomething
  {
       string name {get;set;}
  }

  public interface IConsumer
  {
       string ost {get;set;}
       void consumeIt(string value, ISomething apa);
       string ReturnSomething(string value = null);
   }

```

will become this ts-code (with the returnPromise option set to true):

```
declare module MyModule {
    // models\test.cs
    export interface ISomething {
        name: string;
    }

    // models\test.cs
    export interface IConsumer {
        ost: string;
        consumeIt (value: string, apa: ISomething): Promise<void>
        ReturnSomething (value?: string): Promise<string>
    }

}
```

I hope you think this is an ok addition to your project and that I have not messed up your code to badly.

/David