### PR TITLE
Add support for generic classes

### DIFF
--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -48,7 +48,7 @@ namespace CSharpModelsToJson
         {
             return new Model()
             {
-                ModelName = node.Identifier.ToString(),
+                ModelName = $"{node.Identifier.ToString()}{node.TypeParameterList?.ToString()}",
                 Fields = node.Members.OfType<FieldDeclarationSyntax>()
                                 .Where(field => IsAccessible(field.Modifiers))
                                 .Select(ConvertField),


### PR DESCRIPTION
Hi,
I was trying couple of tools and extensions for C# types to TypeScript conversion. And I found this one and really liked the way it is written and the way of consuming it with NPM (nice and convenient).

I noticed couple of things when using it. One of them is the support for generic types. The generic type parameters are not taken into consideration when building the model name. So, I ended up adding the support and happy to make my contribution with this PR. 🙂 

/Safeer

PS: I will create separate GitHub Issues for other issues/improvements that I have noticed.