### PR TITLE
Add support for Dictionaries/Collections with arrays and nested types

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -110,21 +110,21 @@ const createConverter = config => {
             propType = array[1];
         }
 
-        const optional = propType.endsWith('?');
-        const simpleCollection = propType.match(simpleCollectionRegex);
         const collection = propType.match(collectionRegex);
         const dictionary = propType.match(dictionaryRegex);
-        const simpleDictionary = propType.match(simpleDictionaryRegex);
 
         let type;
         
         if (collection) {
+            const simpleCollection = propType.match(simpleCollectionRegex);
             propType = simpleCollection ? collection[1] : parseType(collection[1]);
             type = `${convertType(propType)}[]`;
         } else if (dictionary) {
+            const simpleDictionary = propType.match(simpleDictionaryRegex);
             propType = simpleDictionary ? dictionary[2] : parseType(dictionary[2]);
             type = `{ [key: ${convertType(dictionary[1])}]: ${convertType(propType)} }`;
         } else {
+            const optional = propType.endsWith('?');
             type = convertType(optional ? propType.slice(0, propType.length - 1) : propType);
         }
 

--- a/converter.js
+++ b/converter.js
@@ -2,8 +2,11 @@ const path = require('path');
 
 const flatten = arr => arr.reduce((a, b) => a.concat(b), []);
 
-const collectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|HashSet)<([\w\d]+)>\?*$/;
-const dictionaryRegex = /^I?Dictionary<([\w\d]+),\s?([\w\d]+)>\?*$/;
+const arrayRegex = /^(.+)\[\]$/;
+const simpleCollectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|HashSet)<([\w\d]+)>\??$/;
+const collectionRegex = /^(?:I?List|IReadOnlyList|IEnumerable|ICollection|HashSet)<(.+)>\??$/;
+const simpleDictionaryRegex = /^I?Dictionary<([\w\d]+)\s*,\s*([\w\d]+)>\??$/;
+const dictionaryRegex = /^I?Dictionary<([\w\d]+)\s*,\s*(.+)>\??$/;
 
 const defaultTypeTranslations = {
     int: 'number',
@@ -94,21 +97,38 @@ const createConverter = config => {
 
     const convertProperty = property => {
         const optional = property.Type.endsWith('?');
-        const collection = property.Type.match(collectionRegex);
-        const dictionary = property.Type.match(dictionaryRegex);
         const identifier = convertIdentifier(optional ? `${property.Identifier.split(' ')[0]}?` : property.Identifier.split(' ')[0]);
 
-        let type;
-
-        if (collection) {
-            type = `${convertType(collection[1])}[]`;
-        } else if (dictionary) {
-            type = `{ [index: ${convertType(dictionary[1])}]: ${convertType(dictionary[2])} }`;
-        } else {
-            type = convertType(optional ? property.Type.slice(0, property.Type.length - 1) : property.Type);
-        }
+        const type = parseType(property.Type);
 
         return `    ${identifier}: ${type};`;
+    };
+
+    const parseType = propType => {
+        const array = propType.match(arrayRegex);
+        if (array) {
+            propType = array[1];
+        }
+
+        const optional = propType.endsWith('?');
+        const simpleCollection = propType.match(simpleCollectionRegex);
+        const collection = propType.match(collectionRegex);
+        const dictionary = propType.match(dictionaryRegex);
+        const simpleDictionary = propType.match(simpleDictionaryRegex);
+
+        let type;
+        
+        if (collection) {
+            propType = simpleCollection ? collection[1] : parseType(collection[1]);
+            type = `${convertType(propType)}[]`;
+        } else if (dictionary) {
+            propType = simpleDictionary ? dictionary[2] : parseType(dictionary[2]);
+            type = `{ [key: ${convertType(dictionary[1])}]: ${convertType(propType)} }`;
+        } else {
+            type = convertType(optional ? propType.slice(0, propType.length - 1) : propType);
+        }
+
+        return array ? `${type}[]` : type;
     };
 
     const convertIdentifier = identifier => config.camelCase ? identifier[0].toLowerCase() + identifier.substring(1) : identifier;


### PR DESCRIPTION
Add support for Dictionaries/Collections with arrays and nested types [Fixes #12]

**C#:**
```cs
public class ErrorResponse
{
    public string ErrorCode { get; set; }
    public IEnumerable<string> Errors { get; set; }
    public IDictionary<string, string[]> ErrorData { get; set; }

    public IDictionary<string, IList<string>> Test1 { get; set; }
    public IDictionary<string, string> Test2 { get; set; }
    public IList<IList<SomeType>> Test3 { get; set; }
    public IDictionary<string[], string> Test4 { get; set; }
    public IDictionary<string, IList<IList<IDictionary<int, string[]>>>> SomethingUnusual { get; set; }
}
```

> **Note:**
> Conversion of `Dictionary` with array or generic type as the key is not supported by this PR. Also, it is not a valid object definition in TypeScript (For example: `IDictionary<string[], string>`). Hence, those types will not be converted.

**Output:**
```ts
export interface ErrorResponse {
    errorCode: string;
    errors: string[];
    errorData: { [key: string]: string[] };
    test1: { [key: string]: string[] };
    test2: { [key: string]: string };
    test3: SomeType[][];
    test4: IDictionary<string[], string>; // not converted.
    somethingUnusual: { [key: string]: { [key: number]: string[] }[][] };
}
```
I also changed the Dictionary object key name from `index` to `key`. 🙂 

Thanks,
Safeer