### PR TITLE
Changes config.output fallback from ".json" to ".d.ts" to align with file content

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ try {
     return console.error(`Configuration file "${configPath}" contains invalid JSON.`);
 }
 
-const output = config.output || 'types.json';
+const output = config.output || 'types.d.ts';
 
 const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},


### PR DESCRIPTION
The fallback value for when `config.output` does not exists results in a `types.json` file, but the actual content of the file is not JSON. 

This PR changes the fallback file from `types.json` to `types.d.ts` to align with the actual content of the file being generated.