### PR TITLE
Insert @deprecated comment when type is Obsolete in C#

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -123,12 +123,15 @@ const createConverter = config => {
         } else {
             rows.push(`export enum ${enum_.Identifier} {`);
 
-            entries.forEach(([key, value]) => {
+            entries.forEach(([key, entrie]) => {
+                if (entrie.Obsolete) {
+                    rows.push(formatObsoleteMessage(entrie.ObsoleteMessage, '    '));
+                }
                 if (config.numericEnums) {
-                    if (value == null) {
+                    if (entrie.Value == null) {
                         rows.push(`    ${key},`);
                     } else {
-                        rows.push(`    ${key} = ${value},`);
+                        rows.push(`    ${key} = ${entrie.Value},`);
                     }
                 } else {
                     rows.push(`    ${key} = '${getEnumStringValue(key)}',`);

--- a/converter.js
+++ b/converter.js
@@ -123,15 +123,15 @@ const createConverter = config => {
         } else {
             rows.push(`export enum ${enum_.Identifier} {`);
 
-            entries.forEach(([key, entrie]) => {
-                if (entrie.Obsolete) {
-                    rows.push(formatObsoleteMessage(entrie.ObsoleteMessage, '    '));
+            entries.forEach(([key, entry]) => {
+                if (entry.Obsolete) {
+                    rows.push(formatObsoleteMessage(entry.ObsoleteMessage, '    '));
                 }
                 if (config.numericEnums) {
-                    if (entrie.Value == null) {
+                    if (entry.Value == null) {
                         rows.push(`    ${key},`);
                     } else {
-                        rows.push(`    ${key} = ${entrie.Value},`);
+                        rows.push(`    ${key} = ${entry.Value},`);
                     }
                 } else {
                     rows.push(`    ${key} = '${getEnumStringValue(key)}',`);
@@ -144,7 +144,7 @@ const createConverter = config => {
         return rows;
     };
 
-    const formatObsoleteMessage = (obsoleteMessage, identation) => {
+    const formatObsoleteMessage = (obsoleteMessage, indentation) => {
         if (obsoleteMessage) {
             obsoleteMessage = ' ' + obsoleteMessage;
         } else {
@@ -152,9 +152,9 @@ const createConverter = config => {
         }
 
         let deprecationMessage = '';
-        deprecationMessage += `${identation}/**\n`;
-        deprecationMessage += `${identation} * @deprecated${obsoleteMessage}\n`;
-        deprecationMessage += `${identation} */`;
+        deprecationMessage += `${indentation}/**\n`;
+        deprecationMessage += `${indentation} * @deprecated${obsoleteMessage}\n`;
+        deprecationMessage += `${indentation} */`;
 
         return deprecationMessage;
     }

--- a/converter.js
+++ b/converter.js
@@ -70,6 +70,9 @@ const createConverter = config => {
         if (!config.omitFilePathComment) {
             rows.push(`// ${filename}`);
         }
+        if (model.Obsolete) {
+            rows.push(formatObsoleteMessage(model.ObsoleteMessage, ''));
+        }
         rows.push(`export interface ${model.ModelName}${baseClasses} {`);
 
         const propertySemicolon = config.omitSemicolon ? '' : ';';
@@ -79,6 +82,9 @@ const createConverter = config => {
         }
 
         members.forEach(member => {
+            if (member.Obsolete) {
+                rows.push(formatObsoleteMessage(member.ObsoleteMessage, '    '));
+            }
             rows.push(`    ${convertProperty(member)}${propertySemicolon}`);
         });
 
@@ -94,6 +100,10 @@ const createConverter = config => {
         }
 
         const entries = Object.entries(enum_.Values);
+
+        if (enum_.Obsolete) {
+            rows.push(formatObsoleteMessage(enum_.ObsoleteMessage, ''));
+        }
 
         const getEnumStringValue = (value) => config.camelCaseEnums
             ? camelcase(value)
@@ -130,6 +140,21 @@ const createConverter = config => {
 
         return rows;
     };
+
+    const formatObsoleteMessage = (obsoleteMessage, identation) => {
+        if (obsoleteMessage) {
+            obsoleteMessage = ' ' + obsoleteMessage;
+        } else {
+            obsoleteMessage = '';
+        }
+
+        let deprecationMessage = '';
+        deprecationMessage += `${identation}/**\n`;
+        deprecationMessage += `${identation} * @deprecated${obsoleteMessage}\n`;
+        deprecationMessage += `${identation} */`;
+
+        return deprecationMessage;
+    }
 
     const convertProperty = property => {
         const optional = property.Type.endsWith('?');

--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ dotnetProcess.stderr.on('data', err => {
 dotnetProcess.stdout.on('end', () => {
     let json;
 
+    //console.log(stdout);
+
     try {
         // Extract the JSON content between the markers
         const startMarker = '<<<<<<START_JSON>>>>>>';

--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
  
@@ -8,6 +7,8 @@ namespace CSharpModelsToJson
     public class Enum
     {
         public string Identifier { get; set; }
+        public bool Obsolete { get; set; }
+        public string ObsoleteMessage { get; set; }
         public Dictionary<string, object> Values { get; set; }
     }
 
@@ -29,6 +30,8 @@ namespace CSharpModelsToJson
 
             this.Enums.Add(new Enum() {
                 Identifier = node.Identifier.ToString(),
+                Obsolete = Util.IsObsolete(node.AttributeLists),
+                ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
                 Values = values
             });
         }

--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -12,6 +12,9 @@ namespace CSharpModelsToJson
         public IEnumerable<Field> Fields { get; set; }
         public IEnumerable<Property> Properties { get; set; }
         public IEnumerable<string> BaseClasses { get; set; }
+        public bool Obsolete { get; set; }
+        public string ObsoleteMessage { get; set; }
+
     }
 
     public class Field
@@ -24,6 +27,8 @@ namespace CSharpModelsToJson
     {
         public string Identifier { get; set; }
         public string Type { get; set; }
+        public bool Obsolete { get; set; }
+        public string ObsoleteMessage { get; set; }
     }
 
     public class ModelCollector : CSharpSyntaxWalker
@@ -81,6 +86,8 @@ namespace CSharpModelsToJson
                                 .Where(property => !IsIgnored(property.AttributeLists))
                                 .Select(ConvertProperty),
                 BaseClasses = node.BaseList?.Types.Select(s => s.ToString()),
+                Obsolete = Util.IsObsolete(node.AttributeLists),
+                ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
             };
         }
 
@@ -105,6 +112,8 @@ namespace CSharpModelsToJson
         {
             Identifier = property.Identifier.ToString(),
             Type = property.Type.ToString(),
+            Obsolete = Util.IsObsolete(property.AttributeLists),
+            ObsoleteMessage = Util.GetObsoleteMessage(property.AttributeLists)
         };
     }
 }

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -43,6 +43,7 @@ namespace CSharpModelsToJson
             sb.AppendLine(json);
             sb.AppendLine("<<<<<<END_JSON>>>>>>");
 
+            System.Console.OutputEncoding = System.Text.Encoding.UTF8;
             System.Console.WriteLine(sb.ToString());
         }
 

--- a/lib/csharp-models-to-json/Program.cs
+++ b/lib/csharp-models-to-json/Program.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Configuration;
 using Ganss.IO;
-using System.Text;
 
 namespace CSharpModelsToJson
 {
@@ -36,7 +37,12 @@ namespace CSharpModelsToJson
                 files.Add(parseFile(fileName));
             }
 
-            string json = JsonSerializer.Serialize(files);
+            JsonSerializerOptions options = new()
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+
+            string json = JsonSerializer.Serialize(files, options);
 
             var sb = new StringBuilder();
             sb.AppendLine("<<<<<<START_JSON>>>>>>");

--- a/lib/csharp-models-to-json/Util.cs
+++ b/lib/csharp-models-to-json/Util.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+
+namespace CSharpModelsToJson
+{
+    internal static class Util
+    {
+        internal static bool IsObsolete(SyntaxList<AttributeListSyntax> attributeLists) =>
+            attributeLists.Any(attributeList =>
+                attributeList.Attributes.Any(attribute =>
+                    attribute.Name.ToString().Equals("Obsolete") || attribute.Name.ToString().Equals("ObsoleteAttribute")));
+
+        internal static string GetObsoleteMessage(SyntaxList<AttributeListSyntax> attributeLists)
+        {
+            foreach (var attributeList in attributeLists)
+            {
+                var obsoleteAttribute =
+                    attributeList.Attributes.FirstOrDefault(attribute =>
+                        attribute.Name.ToString().Equals("Obsolete") || attribute.Name.ToString().Equals("ObsoleteAttribute"));
+
+                if (obsoleteAttribute != null)
+                    return obsoleteAttribute.ArgumentList == null
+                        ? null
+                        : obsoleteAttribute.ArgumentList.Arguments.ToString()?.TrimStart('@').Trim('"');
+            }
+
+            return null;
+        }
+    }
+}

--- a/lib/csharp-models-to-json_test/EnumCollector_test.cs
+++ b/lib/csharp-models-to-json_test/EnumCollector_test.cs
@@ -32,12 +32,11 @@ namespace CSharpModelsToJson.Tests
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Values, Is.Not.Null);
 
-            var values = model.Values.ToArray();
-            Assert.That(values[0].Value, Is.Null);
-            Assert.That(values[1].Value, Is.EqualTo("7"));
-            Assert.That(values[2].Value, Is.Null);
-            Assert.That(values[3].Value, Is.EqualTo("4"));
-            Assert.That(values[4].Value, Is.Null);
+            Assert.That(model.Values["A"].Value, Is.Null);
+            Assert.That(model.Values["B"].Value, Is.EqualTo("7"));
+            Assert.That(model.Values["C"].Value, Is.Null);
+            Assert.That(model.Values["D"].Value, Is.EqualTo("4"));
+            Assert.That(model.Values["E"].Value, Is.Null);
         }
     }
 }

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -257,12 +257,12 @@ namespace CSharpModelsToJson.Tests
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Values, Is.Not.Null);
 
-            Assert.That(model.Values["A"], Is.EqualTo("1"));
-            Assert.That(model.Values["B"], Is.EqualTo("1002"));
-            Assert.That(model.Values["C"], Is.EqualTo("0b011"));
-            Assert.That(model.Values["D"], Is.EqualTo("0b00000100"));
-            Assert.That(model.Values["E"], Is.EqualTo("0x005"));
-            Assert.That(model.Values["F"], Is.EqualTo("0x00001a"));
+            Assert.That(model.Values["A"].Value, Is.EqualTo("1"));
+            Assert.That(model.Values["B"].Value, Is.EqualTo("1002"));
+            Assert.That(model.Values["C"].Value, Is.EqualTo("0b011"));
+            Assert.That(model.Values["D"].Value, Is.EqualTo("0b00000100"));
+            Assert.That(model.Values["E"].Value, Is.EqualTo("0x005"));
+            Assert.That(model.Values["F"].Value, Is.EqualTo("0x00001a"));
         }
 
     }

--- a/test-files/TestFile.cs
+++ b/test-files/TestFile.cs
@@ -30,6 +30,7 @@ namespace TestNamespace
         D = 0b_0000_0100,   // binary: 4 in decimal
         E = 0x005,          // hexadecimal: 5 in decimal
         F = 0x000_01a,      // hexadecimal: 26 in decimal
+        [Obsolete("obsolete test enum")]
         G                   // 27 in decimal
     }
 }

--- a/test-files/TestFile.cs
+++ b/test-files/TestFile.cs
@@ -15,6 +15,7 @@ namespace TestNamespace
         /// </summary>
         public int IntProperty { get; set; }
 
+        [Obsolete("obsolete test prop")]
         public string StringProperty { get; set; }
 
         public DateTime DateTimeProperty { get; set; }


### PR DESCRIPTION
Adds `@deprecated` comment on typescript types when it has `Obsolete` attribute in C#.

It's looking for the `[Obsolete]` attribute on classes, interfaces and enums.