### PR TITLE
Comments annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ npm install --save csharp-models-to-typescript
     ],
     "namespace": "Api",
     "output": "./api.d.ts",
+    "includeComments": true,
     "camelCase": false,
     "camelCaseEnums": false,
     "camelCaseOptions": {

--- a/converter.js
+++ b/converter.js
@@ -70,9 +70,11 @@ const createConverter = config => {
         if (!config.omitFilePathComment) {
             rows.push(`// ${filename}`);
         }
-        if (model.Obsolete) {
-            rows.push(formatObsoleteMessage(model.ObsoleteMessage, ''));
+        let classCommentRows = formatComment(model.ExtraInfo, '')
+        if (classCommentRows) {
+            rows.push(classCommentRows);
         }
+        
         rows.push(`export interface ${model.ModelName}${baseClasses} {`);
 
         const propertySemicolon = config.omitSemicolon ? '' : ';';
@@ -82,9 +84,11 @@ const createConverter = config => {
         }
 
         members.forEach(member => {
-            if (member.Obsolete) {
-                rows.push(formatObsoleteMessage(member.ObsoleteMessage, '    '));
+            let memberCommentRows = formatComment(member.ExtraInfo, '    ')
+            if (memberCommentRows) {
+                rows.push(memberCommentRows);
             }
+
             rows.push(`    ${convertProperty(member)}${propertySemicolon}`);
         });
 
@@ -101,8 +105,9 @@ const createConverter = config => {
 
         const entries = Object.entries(enum_.Values);
 
-        if (enum_.Obsolete) {
-            rows.push(formatObsoleteMessage(enum_.ObsoleteMessage, ''));
+        let classCommentRows = formatComment(enum_.ExtraInfo, '')
+        if (classCommentRows) {
+            rows.push(classCommentRows);
         }
 
         const getEnumStringValue = (value) => config.camelCaseEnums
@@ -124,8 +129,9 @@ const createConverter = config => {
             rows.push(`export enum ${enum_.Identifier} {`);
 
             entries.forEach(([key, entry]) => {
-                if (entry.Obsolete) {
-                    rows.push(formatObsoleteMessage(entry.ObsoleteMessage, '    '));
+                let classCommentRows = formatComment(entry.ExtraInfo, '    ')
+                if (classCommentRows) {
+                    rows.push(classCommentRows);
                 }
                 if (config.numericEnums) {
                     if (entry.Value == null) {
@@ -144,19 +150,37 @@ const createConverter = config => {
         return rows;
     };
 
-    const formatObsoleteMessage = (obsoleteMessage, indentation) => {
-        if (obsoleteMessage) {
-            obsoleteMessage = ' ' + obsoleteMessage;
-        } else {
-            obsoleteMessage = '';
+    const formatComment = (extraInfo, indentation) => {
+        if (!extraInfo || (!extraInfo.Obsolete && !extraInfo.Summary)) {
+            return undefined;
         }
 
-        let deprecationMessage = '';
-        deprecationMessage += `${indentation}/**\n`;
-        deprecationMessage += `${indentation} * @deprecated${obsoleteMessage}\n`;
-        deprecationMessage += `${indentation} */`;
+        let comment = '';
+        comment += `${indentation}/**\n`;
 
-        return deprecationMessage;
+        if (extraInfo.Summary) {
+            let commentLines = extraInfo.Summary.split(/\r?\n/);
+            commentLines = commentLines.map((e) => {
+                return `${indentation} * ${e}\n`;
+            })
+            comment += commentLines.join('');
+        }
+
+        if (extraInfo.Obsolete) {
+            if (extraInfo.Summary) {
+                comment += `${indentation} *\n`;
+            }
+
+            let obsoleteMessage = '';
+            if (extraInfo.ObsoleteMessage) {
+                obsoleteMessage = ' ' + extraInfo.ObsoleteMessage;
+            }
+            comment += `${indentation} * @deprecated${obsoleteMessage}\n`;
+        }
+
+        comment += `${indentation} */`;
+
+        return comment;
     }
 
     const convertProperty = property => {

--- a/converter.js
+++ b/converter.js
@@ -151,7 +151,7 @@ const createConverter = config => {
     };
 
     const formatComment = (extraInfo, indentation) => {
-        if (!extraInfo || (!extraInfo.Obsolete && !extraInfo.Summary)) {
+        if (!config.includeComments || !extraInfo || (!extraInfo.Obsolete && !extraInfo.Summary)) {
             return undefined;
         }
 

--- a/converter.js
+++ b/converter.js
@@ -161,7 +161,7 @@ const createConverter = config => {
         if (extraInfo.Summary) {
             let commentLines = extraInfo.Summary.split(/\r?\n/);
             commentLines = commentLines.map((e) => {
-                return `${indentation} * ${e}\n`;
+                return `${indentation} * ${replaceCommentTags(e)}\n`;
             })
             comment += commentLines.join('');
         }
@@ -173,7 +173,7 @@ const createConverter = config => {
 
             let obsoleteMessage = '';
             if (extraInfo.ObsoleteMessage) {
-                obsoleteMessage = ' ' + extraInfo.ObsoleteMessage;
+                obsoleteMessage = ' ' + replaceCommentTags(extraInfo.ObsoleteMessage);
             }
             comment += `${indentation} * @deprecated${obsoleteMessage}\n`;
         }
@@ -181,6 +181,10 @@ const createConverter = config => {
         comment += `${indentation} */`;
 
         return comment;
+    }
+
+    const replaceCommentTags = comment => {
+        return comment.replace(/<see cref="(\w+)"\/>/gi, '{@link $1}');
     }
 
     const convertProperty = property => {

--- a/converter.js
+++ b/converter.js
@@ -195,6 +195,7 @@ const createConverter = config => {
     const replaceCommentTags = comment => {
         return comment
             .replace(/<see cref="(.+)"\/>/gi, '{@link $1}')
+            .replace(/<see cref="(.+)">(.+)<\/see>/gi, '{@link $1 | $2}')
             .replace('<inheritdoc/>', '@inheritDoc');
     }
 

--- a/converter.js
+++ b/converter.js
@@ -165,6 +165,15 @@ const createConverter = config => {
             })
             comment += commentLines.join('');
         }
+        if (extraInfo.Remarks) {
+            comment += `${indentation} *\n`;
+            comment += `${indentation} * @remarks\n`;
+            let commentLines = extraInfo.Remarks.split(/\r?\n/);
+            commentLines = commentLines.map((e) => {
+                return `${indentation} * ${replaceCommentTags(e)}\n`;
+            })
+            comment += commentLines.join('');
+        }
 
         if (extraInfo.Obsolete) {
             if (extraInfo.Summary) {
@@ -184,7 +193,7 @@ const createConverter = config => {
     }
 
     const replaceCommentTags = comment => {
-        return comment.replace(/<see cref="(\w+)"\/>/gi, '{@link $1}');
+        return comment.replace(/<see cref="(.+)"\/>/gi, '{@link $1}');
     }
 
     const convertProperty = property => {

--- a/converter.js
+++ b/converter.js
@@ -193,7 +193,9 @@ const createConverter = config => {
     }
 
     const replaceCommentTags = comment => {
-        return comment.replace(/<see cref="(.+)"\/>/gi, '{@link $1}');
+        return comment
+            .replace(/<see cref="(.+)"\/>/gi, '{@link $1}')
+            .replace('<inheritdoc/>', '@inheritDoc');
     }
 
     const convertProperty = property => {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const output = config.output || 'types.d.ts';
 const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},
     namespace: config.namespace,
-    includeComments: config.includeComments || false,
+    includeComments: config.includeComments ?? true,
     camelCase: config.camelCase || false,
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const output = config.output || 'types.d.ts';
 const converter = createConverter({
     customTypeTranslations: config.customTypeTranslations || {},
     namespace: config.namespace,
+    includeComments: config.includeComments || false,
     camelCase: config.camelCase || false,
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,

--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -39,6 +39,7 @@ namespace CSharpModelsToJson
                         Obsolete = Util.IsObsolete(member.AttributeLists),
                         ObsoleteMessage = Util.GetObsoleteMessage(member.AttributeLists),
                         Summary = Util.GetSummaryMessage(member),
+                        Remarks = Util.GetRemarksMessage(member),
                     }
                 };
 
@@ -52,6 +53,7 @@ namespace CSharpModelsToJson
                     Obsolete = Util.IsObsolete(node.AttributeLists),
                     ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
                     Summary = Util.GetSummaryMessage(node),
+                    Remarks = Util.GetRemarksMessage(node),
                 },
                 Values = values
             });

--- a/lib/csharp-models-to-json/EnumCollector.cs
+++ b/lib/csharp-models-to-json/EnumCollector.cs
@@ -7,16 +7,14 @@ namespace CSharpModelsToJson
     public class Enum
     {
         public string Identifier { get; set; }
-        public bool Obsolete { get; set; }
-        public string ObsoleteMessage { get; set; }
+        public ExtraInfo ExtraInfo { get; set; }
         public Dictionary<string, EnumValue> Values { get; set; }
     }
 
     public class EnumValue
     {
         public string Value { get; set; }
-        public bool Obsolete { get; set; }
-        public string ObsoleteMessage { get; set; }
+        public ExtraInfo ExtraInfo { get; set; }
     }
 
 
@@ -36,8 +34,12 @@ namespace CSharpModelsToJson
                 var value = new EnumValue
                 {
                     Value = equalsValue?.Replace("_", ""),
-                    Obsolete = Util.IsObsolete(member.AttributeLists),
-                    ObsoleteMessage = Util.GetObsoleteMessage(member.AttributeLists)
+                    ExtraInfo = new ExtraInfo
+                    {
+                        Obsolete = Util.IsObsolete(member.AttributeLists),
+                        ObsoleteMessage = Util.GetObsoleteMessage(member.AttributeLists),
+                        Summary = Util.GetSummaryMessage(member),
+                    }
                 };
 
                 values[member.Identifier.ToString()] = value;
@@ -45,8 +47,12 @@ namespace CSharpModelsToJson
 
             this.Enums.Add(new Enum() {
                 Identifier = node.Identifier.ToString(),
-                Obsolete = Util.IsObsolete(node.AttributeLists),
-                ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
+                ExtraInfo = new ExtraInfo
+                {
+                    Obsolete = Util.IsObsolete(node.AttributeLists),
+                    ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
+                    Summary = Util.GetSummaryMessage(node),
+                },
                 Values = values
             });
         }

--- a/lib/csharp-models-to-json/ExtraInfo.cs
+++ b/lib/csharp-models-to-json/ExtraInfo.cs
@@ -1,0 +1,10 @@
+﻿
+namespace CSharpModelsToJson
+{
+    public class ExtraInfo
+    {
+        public bool Obsolete { get; set; }
+        public string ObsoleteMessage { get; set; }
+        public string Summary { get; set; }
+    }
+}

--- a/lib/csharp-models-to-json/ExtraInfo.cs
+++ b/lib/csharp-models-to-json/ExtraInfo.cs
@@ -6,5 +6,6 @@ namespace CSharpModelsToJson
         public bool Obsolete { get; set; }
         public string ObsoleteMessage { get; set; }
         public string Summary { get; set; }
+        public string Remarks { get; set; }
     }
 }

--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -88,6 +88,7 @@ namespace CSharpModelsToJson
                     Obsolete = Util.IsObsolete(node.AttributeLists),
                     ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
                     Summary = Util.GetSummaryMessage(node),
+                    Remarks = Util.GetRemarksMessage(node),
                 }
             };
         }
@@ -119,6 +120,7 @@ namespace CSharpModelsToJson
                 Obsolete = Util.IsObsolete(property.AttributeLists),
                 ObsoleteMessage = Util.GetObsoleteMessage(property.AttributeLists),
                 Summary = Util.GetSummaryMessage(property),
+                Remarks = Util.GetRemarksMessage(property),
             }
         };
     }

--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -12,9 +12,7 @@ namespace CSharpModelsToJson
         public IEnumerable<Field> Fields { get; set; }
         public IEnumerable<Property> Properties { get; set; }
         public IEnumerable<string> BaseClasses { get; set; }
-        public bool Obsolete { get; set; }
-        public string ObsoleteMessage { get; set; }
-
+        public ExtraInfo ExtraInfo { get; set; }
     }
 
     public class Field
@@ -27,8 +25,7 @@ namespace CSharpModelsToJson
     {
         public string Identifier { get; set; }
         public string Type { get; set; }
-        public bool Obsolete { get; set; }
-        public string ObsoleteMessage { get; set; }
+        public ExtraInfo ExtraInfo { get; set; }
     }
 
     public class ModelCollector : CSharpSyntaxWalker
@@ -86,8 +83,12 @@ namespace CSharpModelsToJson
                                 .Where(property => !IsIgnored(property.AttributeLists))
                                 .Select(ConvertProperty),
                 BaseClasses = node.BaseList?.Types.Select(s => s.ToString()),
-                Obsolete = Util.IsObsolete(node.AttributeLists),
-                ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
+                ExtraInfo = new ExtraInfo
+                {
+                    Obsolete = Util.IsObsolete(node.AttributeLists),
+                    ObsoleteMessage = Util.GetObsoleteMessage(node.AttributeLists),
+                    Summary = Util.GetSummaryMessage(node),
+                }
             };
         }
 
@@ -113,8 +114,12 @@ namespace CSharpModelsToJson
         {
             Identifier = property.Identifier.ToString(),
             Type = property.Type.ToString(),
-            Obsolete = Util.IsObsolete(property.AttributeLists),
-            ObsoleteMessage = Util.GetObsoleteMessage(property.AttributeLists)
+            ExtraInfo = new ExtraInfo
+            {
+                Obsolete = Util.IsObsolete(property.AttributeLists),
+                ObsoleteMessage = Util.GetObsoleteMessage(property.AttributeLists),
+                Summary = Util.GetSummaryMessage(property),
+            }
         };
     }
 }

--- a/lib/csharp-models-to-json/Util.cs
+++ b/lib/csharp-models-to-json/Util.cs
@@ -33,16 +33,26 @@ namespace CSharpModelsToJson
             return null;
         }
 
-        internal static string GetSummaryMessage(SyntaxNode @class)
+        internal static string GetSummaryMessage(SyntaxNode classItem)
         {
-            var documentComment = @class.GetDocumentationCommentTriviaSyntax();
+            return GetCommentTag(classItem, "summary");
+        }
+
+        internal static string GetRemarksMessage(SyntaxNode classItem)
+        {
+            return GetCommentTag(classItem, "remarks");
+        }
+
+        private static string GetCommentTag(SyntaxNode classItem, string xmlTag)
+        {
+            var documentComment = classItem.GetDocumentationCommentTriviaSyntax();
 
             if (documentComment == null)
                 return null;
 
             var summaryElement = documentComment.Content
                .OfType<XmlElementSyntax>()
-               .FirstOrDefault(_ => _.StartTag.Name.LocalName.Text == "summary");
+               .FirstOrDefault(_ => _.StartTag.Name.LocalName.Text == xmlTag);
 
             if (summaryElement == null)
                 return null;
@@ -51,7 +61,7 @@ namespace CSharpModelsToJson
                 .Where(_ => _.Kind() == SyntaxKind.XmlTextLiteralToken)
                 .Select(_ => _.Text.Trim())
                 .ToList();
-                 
+
             var summaryContent = summaryElement.Content.ToString();
             summaryContent = Regex.Replace(summaryContent, @"^\s*///\s*", string.Empty, RegexOptions.Multiline);
             summaryContent = Regex.Replace(summaryContent, "^<para>", Environment.NewLine, RegexOptions.Multiline);

--- a/lib/csharp-models-to-json/Util.cs
+++ b/lib/csharp-models-to-json/Util.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace CSharpModelsToJson
 {
@@ -48,11 +49,15 @@ namespace CSharpModelsToJson
 
             var summaryText = summaryElement.DescendantTokens()
                 .Where(_ => _.Kind() == SyntaxKind.XmlTextLiteralToken)
-                .Select(_ => _.Text.Trim());
+                .Select(_ => _.Text.Trim())
+                .ToList();
+                 
+            var summaryContent = summaryElement.Content.ToString();
+            summaryContent = Regex.Replace(summaryContent, @"^\s*///\s*", string.Empty, RegexOptions.Multiline);
+            summaryContent = Regex.Replace(summaryContent, "^<para>", Environment.NewLine, RegexOptions.Multiline);
+            summaryContent = Regex.Replace(summaryContent, "</para>", string.Empty);
 
-            //var text = documentComment.GetXmlTextSyntax();
-            
-            return string.Join(Environment.NewLine, summaryText).Trim();
+            return summaryContent.Trim();
         }
 
         public static DocumentationCommentTriviaSyntax GetDocumentationCommentTriviaSyntax(this SyntaxNode node)

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -200,14 +200,14 @@ namespace CSharpModelsToJson.Tests
             Assert.That(model, Is.Not.Null);
             Assert.That(model.Properties, Is.Not.Null);
 
-            Assert.That(model.Obsolete, Is.True);
-            Assert.That(model.ObsoleteMessage, Is.EqualTo("test"));
+            Assert.That(model.ExtraInfo.Obsolete, Is.True);
+            Assert.That(model.ExtraInfo.ObsoleteMessage, Is.EqualTo("test"));
 
-            Assert.That(model.Properties.First(x => x.Identifier.Equals("A")).Obsolete, Is.True);
-            Assert.That(model.Properties.First(x => x.Identifier.Equals("A")).ObsoleteMessage, Is.EqualTo("test prop"));
+            Assert.That(model.Properties.First(x => x.Identifier.Equals("A")).ExtraInfo.Obsolete, Is.True);
+            Assert.That(model.Properties.First(x => x.Identifier.Equals("A")).ExtraInfo.ObsoleteMessage, Is.EqualTo("test prop"));
 
-            Assert.That(model.Properties.First(x => x.Identifier.Equals("B")).Obsolete, Is.False);
-            Assert.That(model.Properties.First(x => x.Identifier.Equals("B")).ObsoleteMessage, Is.Null);
+            Assert.That(model.Properties.First(x => x.Identifier.Equals("B")).ExtraInfo.Obsolete, Is.False);
+            Assert.That(model.Properties.First(x => x.Identifier.Equals("B")).ExtraInfo.ObsoleteMessage, Is.Null);
         }
 
         [Test]
@@ -232,8 +232,8 @@ namespace CSharpModelsToJson.Tests
             Assert.That(model, Is.Not.Null) ;
             Assert.That(model.Values, Is.Not.Null);
 
-            Assert.That(model.Obsolete, Is.True);
-            Assert.That(model.ObsoleteMessage, Is.EqualTo("test"));
+            Assert.That(model.ExtraInfo.Obsolete, Is.True);
+            Assert.That(model.ExtraInfo.ObsoleteMessage, Is.EqualTo("test"));
         }
 
         [Test]


### PR DESCRIPTION
- Add comments info to types, enums and members.
- Config `includeComments` to enable/disable comments. Default is True.

Comments include C# tags `Summary` and `Remarks`. And has validation to transform tags `para` and `see` in the comment text.

![image](https://github.com/svenheden/csharp-models-to-typescript/assets/17618149/d78f6b99-71b0-447f-9a46-3e9f10231b7a)
