### PR TITLE
Nullable when EmitDefaultValue is False

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ npm install --save csharp-models-to-typescript
         "locale": "en-US"
     },
     "numericEnums": false,
+    "validateEmitDefaultValue": false,
     "omitFilePathComment": false,
     "omitSemicolon": false,
     "stringLiteralTypesInsteadOfEnums": false,

--- a/converter.js
+++ b/converter.js
@@ -200,7 +200,9 @@ const createConverter = config => {
     }
 
     const convertProperty = property => {
-        const optional = property.Type.endsWith('?');
+        const optional = property.Type.endsWith('?') || (config.validateEmitDefaultValue && 
+                                                         property.ExtraInfo != null && 
+                                                         !property.ExtraInfo.EmitDefaultValue);
         const identifier = convertIdentifier(optional ? `${property.Identifier.split(' ')[0]}?` : property.Identifier.split(' ')[0]);
 
         const type = parseType(property.Type);

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const converter = createConverter({
     camelCaseOptions: config.camelCaseOptions || {},
     camelCaseEnums: config.camelCaseEnums || false,
     numericEnums: config.numericEnums || false,
+    validateEmitDefaultValue: config.validateEmitDefaultValue || false,
     omitFilePathComment: config.omitFilePathComment || false,
     omitSemicolon: config.omitSemicolon || false,
     stringLiteralTypesInsteadOfEnums: config.stringLiteralTypesInsteadOfEnums || false

--- a/lib/csharp-models-to-json/ExtraInfo.cs
+++ b/lib/csharp-models-to-json/ExtraInfo.cs
@@ -7,5 +7,6 @@ namespace CSharpModelsToJson
         public string ObsoleteMessage { get; set; }
         public string Summary { get; set; }
         public string Remarks { get; set; }
+        public bool EmitDefaultValue { get; set; }
     }
 }

--- a/lib/csharp-models-to-json/ModelCollector.cs
+++ b/lib/csharp-models-to-json/ModelCollector.cs
@@ -121,6 +121,7 @@ namespace CSharpModelsToJson
                 ObsoleteMessage = Util.GetObsoleteMessage(property.AttributeLists),
                 Summary = Util.GetSummaryMessage(property),
                 Remarks = Util.GetRemarksMessage(property),
+                EmitDefaultValue = Util.GetEmitDefaultValue(property.AttributeLists),
             }
         };
     }

--- a/lib/csharp-models-to-json/Util.cs
+++ b/lib/csharp-models-to-json/Util.cs
@@ -89,5 +89,22 @@ namespace CSharpModelsToJson
 
             return null;
         }
+
+        internal static bool GetEmitDefaultValue(SyntaxList<AttributeListSyntax> attributeLists)
+        {
+            var dataMemberAttribute = attributeLists
+                .SelectMany(attributeList => attributeList.Attributes)
+                .FirstOrDefault(attribute => attribute.Name.ToString().Equals("DataMember") || attribute.Name.ToString().Equals("DataMemberAttribute"));
+
+            if (dataMemberAttribute?.ArgumentList == null)
+                return true;
+
+            var emitDefaultValueArgument = dataMemberAttribute.ArgumentList.Arguments.FirstOrDefault(x => x.ToString().StartsWith("EmitDefaultValue"));
+
+            if (emitDefaultValueArgument == null)
+                return true;
+
+            return !emitDefaultValueArgument.ToString().EndsWith("false");
+        }
     }
 }

--- a/lib/csharp-models-to-json_test/ModelCollector_test.cs
+++ b/lib/csharp-models-to-json_test/ModelCollector_test.cs
@@ -268,5 +268,44 @@ namespace CSharpModelsToJson.Tests
             Assert.That(model.Values["F"].Value, Is.EqualTo("0x00001a"));
         }
 
+        [Test]
+        public void ReturnEmmitDefaultValueInfo()
+        {
+            var tree = CSharpSyntaxTree.ParseText(@"
+                public class A
+                {
+                    [DataMember(EmitDefaultValue = false)]
+                    public bool Prop1 { get; set; }
+
+                    [DataMember(EmitDefaultValue = true)]
+                    public bool Prop2 { get; set; }
+
+                    [DataMember( EmitDefaultValue = false )]
+                    public bool Prop3 { get; set; }
+
+                    [DataMember]
+                    public bool Prop4 { get; set; }
+
+                    public bool Prop5 { get; set; }
+                }"
+            );
+
+            var root = (CompilationUnitSyntax)tree.GetRoot();
+
+            var modelCollector = new ModelCollector();
+            modelCollector.Visit(root);
+
+            Assert.That(modelCollector.Models, Is.Not.Null);
+            Assert.That(modelCollector.Models.Count, Is.EqualTo(1));
+            
+            var properties = modelCollector.Models.First().Properties;
+
+            Assert.That(properties.First(x => x.Identifier == "Prop1").ExtraInfo.EmitDefaultValue, Is.False);
+            Assert.That(properties.First(x => x.Identifier == "Prop2").ExtraInfo.EmitDefaultValue, Is.True);
+            Assert.That(properties.First(x => x.Identifier == "Prop3").ExtraInfo.EmitDefaultValue, Is.False);
+            Assert.That(properties.First(x => x.Identifier == "Prop4").ExtraInfo.EmitDefaultValue, Is.True);
+            Assert.That(properties.First(x => x.Identifier == "Prop5").ExtraInfo.EmitDefaultValue, Is.True);
+        }
+
     }
 }

--- a/test-files/TestFile.cs
+++ b/test-files/TestFile.cs
@@ -18,6 +18,7 @@ namespace TestNamespace
         [Obsolete("obsolete test prop")]
         public string StringProperty { get; set; }
 
+        [DataMember(EmitDefaultValue = false)]
         public DateTime DateTimeProperty { get; set; }
 
         public bool BooleanProperty { get; set; }

--- a/test-files/test-config.json
+++ b/test-files/test-config.json
@@ -13,6 +13,7 @@
   },
   "includeComments": true,
   "numericEnums": true,
+  "validateEmitDefaultValue": true,
   "omitSemicolon": true,
   "omitFilePathComment": true,
   "stringLiteralTypesInsteadOfEnums": false,


### PR DESCRIPTION
Option to validate C# `EmitDefaultValue` into `DataMember` attribute.

If EmitDefaultValue is false, then the TypeScript property is Nullable.

In example, C# source:
```csharp
public class A
{
    [DataMember(EmitDefaultValue = false)]
    public bool Prop1 { get; set; }

    public bool Prop2 { get; set; }
}
```

Will be converted to TypeScript:
```typescript
export interface A {
    Prop1?: boolean
    Prop2: boolean
}
```